### PR TITLE
Fix getJvmMaxMemory returning a string when it should be an int

### DIFF
--- a/pyworkflow/em/showj.py
+++ b/pyworkflow/em/showj.py
@@ -26,7 +26,7 @@
 """
 Configuration definition for launching the ShowJ visualization utility.
 The name of ShowJ is due historical reasons. This data visualization tools
-was first called xmipp_show. And later was re-written using Java and 
+was first called xmipp_show. And later was re-written using Java and
 became xmipp_showj.
 """
 
@@ -105,7 +105,7 @@ OBJECT_ID = 'objectId'
 
 def getJvmMaxMemory():
     # Memory in GB
-    return os.environ.get("JAVA_MAX_MEMORY", 2)
+    return int(os.environ.get("JAVA_MAX_MEMORY", 2))
 
 
 class ColumnsConfig():
@@ -122,97 +122,97 @@ class ColumnsConfig():
     - renderFuncExtra
     """
     def __init__(self, table, allowRender=True, defaultColumnsLayout={}):
-        
+
         self._columnsDict = OrderedDict()
-         
-        for col in table.iterColumns():  
+
+        for col in table.iterColumns():
             colDefaultLayout = defaultColumnsLayout.get(col.getLabel(), {})
             col_properties = ColumnProperties(col, allowRender, colDefaultLayout)
             self._columnsDict[col.getName()] = col_properties
-        
+
     def getRenderableColumns(self, extra=None):
-        """ Return a list with the name of renderable columns. 
+        """ Return a list with the name of renderable columns.
             extra: parameter used to keep some rendering columns."""
         columnsName = []
         columnsLabel = []
-        
+
         for col in self._columnsDict.values():
             if col.isRenderable():
                 if extra is not None:
                     if col.getName() in extra:
                         columnsName.append(col.getName())
                         columnsLabel.append(col.getLabel())
-                        
+
                 else:
                     columnsName.append(col.getName())
                     columnsLabel.append(col.getLabel())
 #       columns = [col.getName() for col in self._columnsDict.values() if col.isRenderable()]
         return columnsName, columnsLabel
-    
+
     def hasEnableColumn(self):
         for columnLayout in self._columnsDict.values():
             if "enable" == columnLayout.label:
                 return True
         return False
-    
+
     def getColumnProperty(self, colName, propName):
         """ Get some property value of a given column. """
         col = self._columnsDict[colName]
         return getattr(col, propName)
-    
+
     def configColumn(self, colName, **kwargs):
         """ Configure properties of a given column. """
         col = self._columnsDict[colName]
         for k, v in kwargs.iteritems():
             setattr(col, k, v)
-            
+
     def printColumns(self):
         for col in self._columnsDict.values():
             print "column: ", col.getLabel()
             print "  values: ", col.getValues()
-        
-            
+
+
 class ColumnProperties():
     """ Store some properties to customize how each column
-    will be display in the table. 
+    will be display in the table.
     """
     def __init__(self, col, allowRender, defaultColumnLayoutProperties):
-        self._column = col        
+        self._column = col
         self.columnType = col.getRenderType()
-        
+
         if 'visible' in defaultColumnLayoutProperties:
             self.visible = defaultColumnLayoutProperties['visible']
         else:
             self.visible = not (self.columnType == COL_RENDER_ID)
-            
-        self.allowSetVisible = True 
-        
+
+        self.allowSetVisible = True
+
         self.editable = (self.columnType == COL_RENDER_TEXT)
         self.allowSetEditable = self.editable
-        
+
         self.renderable = 'renderable' in defaultColumnLayoutProperties and defaultColumnLayoutProperties['renderable'].lower() == 'true'
-            
+
         self.allowSetRenderable = ((self.columnType == COL_RENDER_IMAGE or
                                    self.columnType == COL_RENDER_VOLUME) and allowRender)
 
         self.renderFunc = "get_image"
         self.extraRenderFunc = ""
-        
+
     def getLabel(self):
         return self._column.getLabel()
-    
+
     def getName(self):
         return self._column.getName()
-    
+
     def getColumnType(self):
         return self.columnType
-    
+
     def allowsRenderable(self):
         self.renderable or self.allowSetRenderable
-        
+
     def isRenderable(self):
         return self.renderable or self.allowSetRenderable
-        
+
     def setValues(self, defaultColumnLayoutProperties):
         for key in defaultColumnLayoutProperties:
             setattr(self, key, defaultColumnLayoutProperties[key])
@@ -238,20 +238,20 @@ def getArchitecture():
     for a in ['32', '64']:
         if a in arch:
             return a
-    return 'NO_ARCH' 
+    return 'NO_ARCH'
 
 
 def getJavaIJappArguments(memory, appName, appArgs):
-    """ Build the command line arguments to launch 
-    a Java application based on ImageJ. 
+    """ Build the command line arguments to launch
+    a Java application based on ImageJ.
     memory: the amount of memory passed to the JVM.
     appName: the qualified name of the java application.
     appArgs: the arguments specific to the application.
-    """ 
+    """
     if memory is None:
         memory = getJvmMaxMemory()
         print "No memory size provided. Using default: %s" % memory
-    
+
     jdkLib = join(os.environ['JAVA_HOME'], 'lib')
     imagej_home = join(os.environ['XMIPP_HOME'], "external", "imagej")
     lib = join(os.environ['XMIPP_HOME'], "lib")
@@ -293,16 +293,16 @@ def launchSupervisedPickerGUI(micsFn, outputDir, protocol, mode=None,
             args += " --tmp true"
 
         return runJavaIJapp(memory, app, args)
-    
+
 
 def launchTiltPairPickerGUI(micsFn, outputDir, protocol, mode=None, memory='2g'):
         port = initProtocolTCPServer(protocol)
         app = "xmipp.viewer.particlepicker.tiltpair.TiltPairPickerRunner"
         args = "--input %s --output %s  --scipion %s"%(micsFn, outputDir, port)
         if mode:
-            args += " --mode %s"%mode    
+            args += " --mode %s"%mode
         return runJavaIJapp("%s" % memory, app, args)
-    
+
 
 class ProtocolTCPRequestHandler(SocketServer.BaseRequestHandler):
 
@@ -331,8 +331,8 @@ class MySocketServer (SocketServer.TCPServer):
         self.end = False
         while not self.end:
             self.handle_request()
-    
-    
+
+
 def initProtocolTCPServer(protocol):
         address = ''
         port = getFreePort()
@@ -342,5 +342,3 @@ def initProtocolTCPServer(protocol):
         server_thread.daemon = True
         server_thread.start()
         return port
-
-


### PR DESCRIPTION
The getJvmMaxMemory function will return a string, if the JAVA_MAX_MEMORY system variable is set, while the it will default to return the int 2 if it is not set. This causes a TypeError when trying to increment the memory by 1 in the pyworkflows/em/packages/xmipp3/viewer.py (line 161):
`moviesView.setMemory(showj.getJvmMaxMemory() + 1)`

It seem my editor has removed a lot of spaces and tabs - I hope this isn't a problem. The actual change is in line 108.
Also, as this is my first time making a pull request on github, please let me know if I'm doing it wrong!